### PR TITLE
change readme.md -> README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ elif _system == 'Darwin':
 
 __doc__ = 'Library to provide speech and braille output to a variety of different screen readers and other accessibility solutions.',
 
-with io.open('readme.md', encoding='UTF8') as readme:
+with io.open('README.md', encoding='UTF8') as readme:
 	long_description = readme.read()
 
 setup(


### PR DESCRIPTION
Seems like setup.py fails on case-sensitive file systems.

```
Collecting git+https://github.com/manuelcortez/accessible_output2 (from -r ../requirements.txt (line 30))
  Cloning https://github.com/manuelcortez/accessible_output2 to /tmp/pip-req-build-H5PKWe
  Running command git clone -q https://github.com/manuelcortez/accessible_output2 /tmp/pip-req-build-H5PKWe
    ERROR: Command errored out with exit status 1:
     command: /mnt/c/Users/ColeGleason/Documents/GitHub/TWBlue/env/bin/python2 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-H5PKWe/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-H5PKWe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-req-build-H5PKWe/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-H5PKWe/setup.py", line 20, in <module>
        with io.open('readme.md', encoding='UTF8') as readme:
    IOError: [Errno 2] No such file or directory: 'readme.md'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full
command output.
```